### PR TITLE
Run quality workflows only on PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Quality
 
 on:
-  push:
+  pull_request:
 
 jobs:
   pre-commit:


### PR DESCRIPTION
It is unnecessary to run quality workflows on outside of PRs, because it
was already ran in the PR