### PR TITLE
Successful recipe list response is not nil

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -99,6 +99,7 @@ func (h *handlers) List(msg *nats.Msg) {
 
 	list := Envelope[List]{
 		Status: StatusSuccess,
+		Data:   List{},
 	}
 	for _, r := range recipes {
 		list.Data = append(list.Data, EntToRecipe(r))

--- a/api/models.go
+++ b/api/models.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Envelope[T any] struct {
-	Status string
-	Data   T
+	Status string `json:"status"`
+	Data   T      `json:"data"`
 }
 
 type List []Recipe


### PR DESCRIPTION
We don't want to handle cases where the API returns list as nulls. The
API should be consistent and if no recipes are found, return empty
array.