### PR TITLE
fix: specify docker build ARG build_target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          build-args: |
+            build_target=./cmd/api/api.go
           push: true
           file: docker/api.Dockerfile
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Add missing build_target build argument for docker in workflow