### PR TITLE
Utils dev logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,7 @@
 ## how to run on local machine
 
 ```shell
-# build the containers
-./hack/build-containers.sh
-
-# run the stack
-docker compose -f docker/docker-compose.yml up
+# build and run the stack
+docker compose --file docker/docker-compose.yml up --build
 
 ```

--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -9,7 +9,7 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/encero/reciper-api/api"
 	"github.com/encero/reciper-api/ent"
-	"go.uber.org/zap"
+	"github.com/encero/reciper-api/pkg/common"
 	_ "modernc.org/sqlite"
 )
 
@@ -35,7 +35,7 @@ func run() error {
 	entc := ent.NewClient(ent.Driver(entsql.OpenDB("sqlite3", sqldb)))
 	defer entc.Close()
 
-	logger, err := zap.NewProduction()
+	logger, err := common.LoggerFromEnv()
 	if err != nil {
 		return fmt.Errorf("setup logger %w", err)
 	}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,15 +5,30 @@ services:
     image: nats:2.7-alpine
     restart: always
   api:
-    image: reciper-api:latest
+    build:
+      context: ../
+      dockerfile: docker/go.Dockerfile
+      args:
+        build_target: cmd/api/api.go
     environment:
       - NATS_URL=nats://nats:4222
+      - LOGGER=dev
     restart: always
+    depends_on:
+      - nats
   gql:
+    build:
+      context: ../
+      dockerfile: docker/go.Dockerfile
+      args:
+        build_target: gql/server.go
     image: reciper-gql:latest
     environment:
       - NATS_URL=nats://nats:4222
+      - LOGGER=dev
     restart: always
     ports:
       - "8080:8080"
+    depends_on:
+      - nats
         

--- a/gql/server_test.go
+++ b/gql/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/matryer/is"
 	"github.com/matryer/try"
+	"go.uber.org/zap"
 )
 
 func TestAddRecipe(t *testing.T) {
@@ -90,7 +91,7 @@ func setupGQL(t *testing.T, natsURL string) func() {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	go func() {
-		err := run(ctx, tl, "8080", natsURL)
+		err := run(ctx, tl.With(zap.String("system", "gql")), "8080", natsURL)
 		if !errors.Is(err, http.ErrServerClosed) {
 			is.NoErr(err)
 		}

--- a/pkg/common/logger.go
+++ b/pkg/common/logger.go
@@ -1,0 +1,19 @@
+package common
+
+import (
+	"os"
+	"strings"
+
+	"go.uber.org/zap"
+)
+
+func LoggerFromEnv() (*zap.Logger, error) {
+	var loggerConfig zap.Config
+	if strings.ToLower(os.Getenv("LOGGER")) == "dev" {
+		loggerConfig = zap.NewDevelopmentConfig()
+	} else {
+		loggerConfig = zap.NewProductionConfig()
+	}
+
+	return loggerConfig.Build()
+}

--- a/pkg/tests/api.go
+++ b/pkg/tests/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/matryer/is"
 	"github.com/matryer/try"
 	"github.com/nats-io/nats.go"
+	"go.uber.org/zap"
 	_ "modernc.org/sqlite" // intentional for tests
 )
 
@@ -25,7 +26,7 @@ func SetupAPI(t *testing.T) (*is.I, *nats.Conn, func()) {
 	serverDone := make(chan struct{})
 
 	go func() {
-		lg := TestLogger(t)
+		lg := TestLogger(t).With(zap.String("system", "api"))
 		err := api.Run(ctx, entc, lg, natsURL)
 
 		if err != nil {


### PR DESCRIPTION
utils: common way of setting up zap.Logger

This change extract setting up a logger to separate package, so it can
be reused in all go applications.

New environment variable `LOGGER=dev` can be used to enable development
logging.