### PR TITLE
utils: build artifacts on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,12 @@ name: publish
 on:
   release:
     types: [published]
+  push:
+    branches:
+      - "master"
 
 jobs:
-  docker:
+  api:
     runs-on: ubuntu-latest
     steps:
       -
@@ -41,7 +44,48 @@ jobs:
           build-args: |
             build_target=./cmd/api/api.go
           push: true
-          file: docker/api.Dockerfile
+          file: docker/go.Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+  gql:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/encero/reciper-gql
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern={{raw}}
+            type=sha
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          build-args: |
+            build_target=./gql/server.go
+          push: true
+          file: docker/go.Dockerfile
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha


### PR DESCRIPTION
For easier development we need to build artifacts on merge/push to main
branch. Those releases will be tagged only with the SHA of commit.

fix: rename of the docker file for go services was not done in github
actions.