### PR TITLE
api: env variable to configure db file location

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -26,7 +26,12 @@ func run() error {
 		natsURL = url
 	}
 
-	sqldb, err := sql.Open("sqlite", "file:db.lite?cache=shared&_pragma=foreign_keys(1)")
+	dbFile := "db.lite"
+	if file, ok := os.LookupEnv("DB_FILE"); ok {
+		dbFile = file
+	}
+
+	sqldb, err := sql.Open("sqlite", fmt.Sprintf("file:%s?cache=shared&_pragma=foreign_keys(1)", dbFile))
 	if err != nil {
 		return fmt.Errorf("cant open sql database: %w", err)
 	}


### PR DESCRIPTION
This is a preparation for litestream, the env variable controls where
will the api be looking for its database file. Default is ./db.lite