### PR TITLE
Partial cleanup of sever_tests

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,12 +24,12 @@ func TestCreateRecipe(t *testing.T) {
 	is, conn, cleanup := tests.SetupAPI(t)
 	defer cleanup()
 
-	id := upsertRecipe(is, conn, api.Recipe{
+	id := upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   uuid.New(),
 		Name: "The name",
 	})
 
-	r := getRecipe(is, conn, id) // fetch recipe
+	r := getRecipe(is.Is, conn, id) // fetch recipe
 
 	is.Equal(r.Name, "The name") // r.Name
 }
@@ -41,7 +41,7 @@ func TestListRecipes(t *testing.T) {
 	var ids []uuid.UUID
 
 	for i := 0; i < 10; i++ {
-		id := upsertRecipe(is, conn, api.Recipe{
+		id := upsertRecipe(is.Is, conn, api.Recipe{
 			ID:   uuid.New(),
 			Name: fmt.Sprintf("The name #%d", i),
 		}) // create recipe
@@ -49,7 +49,7 @@ func TestListRecipes(t *testing.T) {
 		ids = append(ids, id)
 	}
 
-	list := listRecipes(is, conn) // list recipes
+	list := listRecipes(is.Is, conn) // list recipes
 
 	is.Equal(len(list), 10) // count of recipes
 
@@ -68,7 +68,7 @@ func TestListRecipes_ReturnsEmptyArray(t *testing.T) {
 	is, conn, cleanup := tests.SetupAPI(t)
 	defer cleanup()
 
-	list := listRecipes(is, conn)
+	list := listRecipes(is.Is, conn)
 
 	is.True(list != nil) // empty List response Data should not be nil
 }
@@ -77,17 +77,17 @@ func TestUpdateRecipe(t *testing.T) {
 	is, conn, cleanup := tests.SetupAPI(t)
 	defer cleanup()
 
-	id := upsertRecipe(is, conn, api.Recipe{
+	id := upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   uuid.New(),
 		Name: "The name",
 	})
 
-	_ = upsertRecipe(is, conn, api.Recipe{
+	_ = upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   id,
 		Name: "Different name",
 	})
 
-	r := getRecipe(is, conn, id)
+	r := getRecipe(is.Is, conn, id)
 
 	is.Equal(r.Name, "Different name") // r.Name
 }
@@ -96,16 +96,16 @@ func TestDeleteRecipe(t *testing.T) {
 	is, conn, cleanup := tests.SetupAPI(t)
 	defer cleanup()
 
-	id1 := upsertRecipe(is, conn, api.Recipe{
+	id1 := upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   uuid.New(),
 		Name: "The name",
 	})
-	id2 := upsertRecipe(is, conn, api.Recipe{
+	id2 := upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   uuid.New(),
 		Name: "The name",
 	})
 
-	list := listRecipes(is, conn)
+	list := listRecipes(is.Is, conn)
 	is.Equal(len(list), 2) // two recipes after upsert
 
 	_, err := conn.Request(fmt.Sprintf("recipes.delete.%s", id2), nil, reqTimeout)
@@ -114,7 +114,7 @@ func TestDeleteRecipe(t *testing.T) {
 	_, err = conn.Request(fmt.Sprintf("recipes.delete.%s", id2), nil, reqTimeout)
 	is.NoErr(err) // delete recipe again, should be noop
 
-	list = listRecipes(is, conn)
+	list = listRecipes(is.Is, conn)
 	is.Equal(len(list), 1)    // one recipe ater delter
 	is.Equal(list[0].ID, id1) // correct recipe remains
 }
@@ -123,24 +123,24 @@ func TestMarkRecipeAsPlanned(t *testing.T) {
 	is, conn, cleanup := tests.SetupAPI(t)
 	defer cleanup()
 
-	id := upsertRecipe(is, conn, api.Recipe{
+	id := upsertRecipe(is.Is, conn, api.Recipe{
 		ID:   uuid.New(),
 		Name: "The name",
 	})
 
-	recipes := listRecipes(is, conn)
+	recipes := listRecipes(is.Is, conn)
 	is.Equal(len(recipes), 1)
 	is.Equal(recipes[0].Planned, false) // new recipe is unplanned
 
-	markAsPlanned(is, conn, id, true) // mark recipe as planned
+	markAsPlanned(is.Is, conn, id, true) // mark recipe as planned
 
-	recipes = listRecipes(is, conn)
+	recipes = listRecipes(is.Is, conn)
 	is.Equal(len(recipes), 1)
 	is.True(recipes[0].Planned) // marked recipe is planned
 
-	markAsPlanned(is, conn, id, false) // mark recipe as unplanned
+	markAsPlanned(is.Is, conn, id, false) // mark recipe as unplanned
 
-	recipes = listRecipes(is, conn)
+	recipes = listRecipes(is.Is, conn)
 	is.Equal(len(recipes), 1)
 	is.True(!recipes[0].Planned) // marked recipe is UNplanned
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/klauspost/compress v1.14.4 // indirect
+	github.com/klauspost/compress v1.15.1 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/matryer/moq v0.2.3 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,8 @@ github.com/hashicorp/hcl/v2 v2.10.0/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oay
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinmbeaulieu/eq-go v1.0.0/go.mod h1:G3S8ajA56gKBZm4UB9AOyoOS37JO3roToPzKNM8dtdM=
-github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
-github.com/klauspost/compress v1.14.4/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.15.1 h1:y9FcTHGyrebwfP0ZZqFiaxTaiDnUrGkJkI+f583BL1A=
+github.com/klauspost/compress v1.15.1/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=

--- a/pkg/tests/api.go
+++ b/pkg/tests/api.go
@@ -10,15 +10,14 @@ import (
 	entsql "entgo.io/ent/dialect/sql"
 	"github.com/encero/reciper/api"
 	"github.com/encero/reciper/ent"
-	"github.com/matryer/is"
 	"github.com/matryer/try"
 	"github.com/nats-io/nats.go"
 	"go.uber.org/zap"
 	_ "modernc.org/sqlite" // intentional for tests
 )
 
-func SetupAPI(t *testing.T) (*is.I, *nats.Conn, func()) {
-	is := is.New(t)
+func SetupAPI(t *testing.T) (IsT, *nats.Conn, func()) {
+	is := newIst(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	conn, natsURL, natsCleanup := RunAndConnectNats(t)

--- a/pkg/tests/ist.go
+++ b/pkg/tests/ist.go
@@ -1,0 +1,34 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/matryer/is"
+)
+
+func newIst(t *testing.T) IsT {
+	return IsT{
+		Is: is.New(t),
+		T:  t,
+	}
+}
+
+type IsT struct {
+	Is *is.I
+	T  *testing.T
+}
+
+func (is IsT) NoErr(err error) {
+	is.Is.Helper()
+	is.Is.NoErr(err)
+}
+
+func (is IsT) Equal(a any, b any) {
+	is.Is.Helper()
+	is.Is.Equal(a, b)
+}
+
+func (is IsT) True(a bool) {
+	is.Is.Helper()
+	is.Is.True(a)
+}


### PR DESCRIPTION
Removed most some redundant code around calling the api and
marshaling/demarshaling jsons.

I did consider to use dedicated gql library. In the end the code was
mostly the same as it is now after refactor at cost of less explicit
code and huge dependency for only test code.

Introduced tests.IsT, wrapper around matryer/is and testig.T, this struct
provide both.